### PR TITLE
feat: rework deadlock handling

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -3,59 +3,11 @@
 package handle
 
 import (
-	"errors"
 	"fmt"
 	"io"
-	"os"
-	"reflect"
 	"runtime"
-	"syscall"
 	"time"
-	"unicode/utf16"
-	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
-
-var (
-	modntdll                     = syscall.NewLazyDLL("ntdll.dll")
-	procNtQuerySystemInformation = modntdll.NewProc("NtQuerySystemInformation")
-	procNtQueryObject            = modntdll.NewProc("NtQueryObject")
-)
-
-type unicodeString struct {
-	Length        uint16
-	MaximumLength uint16
-	Buffer        *uint16
-}
-
-type systemHandle struct {
-	UniqueProcessID       uint16
-	CreatorBackTraceIndex uint16
-	ObjectTypeIndex       uint8
-	HandleAttributes      uint8
-	HandleValue           uint16
-	Object                uint3264
-	GrantedAccess         uint3264
-}
-
-type systemHandleInformation struct {
-	Count        uint3264
-	SystemHandle []systemHandle
-}
-
-type objectTypeInformation struct {
-	TypeName unicodeString
-	_        [22]uint64 // unused
-}
-
-type objectNameInformation struct {
-	Name unicodeString
-}
-
-func NtSuccess(rt uint32) bool {
-	return rt < 0x8000000
-}
 
 type Handle struct {
 	Process uint16
@@ -65,32 +17,11 @@ type Handle struct {
 }
 
 func QueryHandles(buf []byte, processFilter *uint16, handleTypes []string, queryTimeout time.Duration) (handles []Handle, err error) {
-	// reset buffer, querying system information seem to require a 0-valued buffer.
-	// Without this reset, the below sysinfo.Count might be wrong.
-	for i := 0; i < len(buf); i++ {
-		buf[i] = 0
-	}
-	ownpid := uint16(os.Getpid())
-	ownprocess, err := windows.GetCurrentProcess()
+	systemHandles, err := NtQuerySystemHandles(buf)
 	if err != nil {
-		return nil, fmt.Errorf("could not get current process: %s", err)
+		return nil, err
 	}
-	defer windows.CloseHandle(ownprocess)
-	// load all handle information to buffer and convert it to systemHandleInformation
-	if err := querySystemInformation(buf); err != nil {
-		return nil, fmt.Errorf("could not query system information: %s", err)
-	}
-	sysinfo := (*systemHandleInformation)(unsafe.Pointer(&buf[0]))
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&sysinfo.SystemHandle))
-	sh.Data = uintptr(unsafe.Pointer(&buf[int(unsafe.Sizeof(sysinfo.Count))]))
-	sh.Len = int(sysinfo.Count)
-	sh.Cap = int(sysinfo.Count)
-	var (
-		typeMapping    = make(map[uint8]string) // what objecttypeindex equals which handletype
-		typeMappingErr = make(map[uint8]int)
-		typeFilter     map[string]struct{}
-		processErrs    = make(map[uint16]struct{})
-	)
+	var typeFilter map[string]struct{}
 	if len(handleTypes) > 0 {
 		typeFilter = make(map[string]struct{})
 		for _, handleType := range handleTypes {
@@ -98,215 +29,39 @@ func QueryHandles(buf []byte, processFilter *uint16, handleTypes []string, query
 		}
 	}
 	log("type filter: %#v", typeFilter)
-	log("sysinfo count: %d", sysinfo.Count)
-	for i := uint3264(0); i < sysinfo.Count; i++ {
-		handle := sysinfo.SystemHandle[i]
+	log("handle count: %d", len(systemHandles))
+	inspector := NewInspector(queryTimeout)
+	defer inspector.Close()
+	for _, handle := range systemHandles {
 		log("handle: %#v", handle)
-		// some handles cause freeze, skip them
-		if (handle.GrantedAccess == 0x0012019f) ||
-			(handle.GrantedAccess == 0x001a019f) ||
-			(handle.GrantedAccess == 0x00120189) ||
-			(handle.GrantedAccess == 0x00100000) {
-			log("skipping handle due to granted access")
-			continue
-		}
 		if processFilter != nil && *processFilter != handle.UniqueProcessID {
 			log("skipping handle of process %d due to process filter %d", handle.UniqueProcessID, processFilter)
 			continue
 		}
-		if _, ok := processErrs[handle.UniqueProcessID]; ok {
+		handleType, err := inspector.LookupHandleType(handle)
+		if err != nil {
+			log("could not query handle type for handle %d in process %d with access mask %d, error: %v", handle.HandleValue, handle.UniqueProcessID, handle.GrantedAccess, err)
 			continue
 		}
-		// unknown type, query the type information
-		if _, ok := typeMapping[handle.ObjectTypeIndex]; !ok {
-			log("handle type %d of handle 0x%X is unknown, querying for type ...", handle.UniqueProcessID, handle.HandleValue)
-			done := make(chan struct{}, 1)
-			var (
-				handleTypeRoutine string
-				errRoutine        error
-			)
-			go func() {
-				handleTypeRoutine, errRoutine = queryTypeInformation(handle, ownprocess, ownpid == handle.UniqueProcessID)
-				done <- struct{}{}
-			}()
-			select {
-			case <-done:
-				if errRoutine == errOpenProcess {
-					log("skipping process %d due to open error", handle.UniqueProcessID)
-					processErrs[handle.UniqueProcessID] = struct{}{}
-					continue
-				}
-				if errRoutine != nil {
-					log("handle type %d could not be queried: %s", handle.ObjectTypeIndex, errRoutine)
-					// to prevent querying tons of types that can't be queries, count errors per
-					// handle type and ignore this type if more than X tries failed.
-					typeMappingErr[handle.ObjectTypeIndex]++
-					if typeMappingErr[handle.ObjectTypeIndex] >= 10 {
-						typeMapping[handle.ObjectTypeIndex] = "unknown"
-					}
-				} else {
-					log("handle type %d is of type %s", handle.ObjectTypeIndex, handleTypeRoutine)
-					typeMapping[handle.ObjectTypeIndex] = handleTypeRoutine
-				}
-			case <-time.After(queryTimeout):
-				log("timeout when querying process %d handle 0x%X with granted access 0x%X", handle.ObjectTypeIndex, handle.HandleValue, handle.GrantedAccess)
-				continue
-			}
-		}
-		handleType := typeMapping[handle.ObjectTypeIndex]
-		log("handle type: %s", handleType)
 		if typeFilter != nil {
-			if _, ok := typeFilter[handleType]; !ok {
-				// handle type not in filter list, skip
-				log("skipping handle type %q due to handle filters", handleType)
+			if _, isTargetType := typeFilter[handleType]; !isTargetType {
 				continue
 			}
 		}
-		switch handleType {
-		default:
-			done := make(chan struct{}, 1)
-			var (
-				nameRoutine string
-				errRoutine  error
-			)
-			go func() {
-				nameRoutine, errRoutine = queryNameInformation(handle, ownprocess, ownpid == handle.UniqueProcessID)
-				done <- struct{}{}
-			}()
-			var name string
-			select {
-			case <-done:
-				if errRoutine != nil {
-					log("could not get handle name for handle 0x%X of type %s: %s", handle.HandleValue, handleType, errRoutine)
-				} else {
-					name = nameRoutine
-				}
-			case <-time.After(queryTimeout):
-				log("timeout when querying for handle name of process %d's handle 0x%X (type %s) and granted access 0x%X", handle.UniqueProcessID, handle.HandleValue, handleType, handle.GrantedAccess)
-			}
-			handle := Handle{Process: handle.UniqueProcessID, Handle: handle.HandleValue, Name: name, Type: handleType}
-			log("handle found: process: %d handle: 0x%X name: %10.10s type: %s", handle.Process, handle.Handle, handle.Name, handle.Type)
-			// add handle to result set
-			handles = append(handles, handle)
+		name, err := inspector.LookupHandleName(handle)
+		if err != nil {
+			log("could not query handle name for handle %d in process %d with access mask %d, error: %v", handle.HandleValue, handle.UniqueProcessID, handle.GrantedAccess, err)
+			continue
 		}
+		handles = append(handles, Handle{
+			Process: handle.UniqueProcessID,
+			Handle:  handle.HandleValue,
+			Name:    name,
+			Type:    handleType,
+		})
 	}
 	runtime.KeepAlive(buf)
 	return handles, nil
-}
-
-func querySystemInformation(buf []byte) error {
-	ret, _, _ := procNtQuerySystemInformation.Call(
-		16,
-		uintptr(unsafe.Pointer(&buf[0])),
-		uintptr(len(buf)),
-		0,
-	)
-	if !NtSuccess(uint32(ret)) {
-		return fmt.Errorf("NTStatus(0x%X)", ret)
-	}
-	return nil
-}
-
-var errOpenProcess = errors.New("could not open process")
-
-func queryTypeInformation(handle systemHandle, ownprocess windows.Handle, ownpid bool) (string, error) {
-	// duplicate handle if it's not from our own process
-	var h windows.Handle
-	if !ownpid {
-		p, err := windows.OpenProcess(
-			windows.PROCESS_DUP_HANDLE,
-			true,
-			uint32(handle.UniqueProcessID),
-		)
-		if err != nil {
-			log("could not open process %d: %s", handle.UniqueProcessID, err)
-			return "", errOpenProcess
-		}
-		defer windows.CloseHandle(p)
-		if err := windows.DuplicateHandle(
-			p,
-			windows.Handle(handle.HandleValue),
-			ownprocess,
-			&h,
-			0,
-			false,
-			windows.DUPLICATE_SAME_ACCESS,
-		); err != nil {
-			log("could not duplicate process handle 0x%X of process %d: %s", handle.HandleValue, handle.UniqueProcessID, err)
-			return "", err
-		}
-		defer windows.CloseHandle(h)
-	} else {
-		h = windows.Handle(handle.HandleValue)
-	}
-	buf := make([]byte, 0x1000)
-	ret, _, _ := procNtQueryObject.Call(
-		uintptr(h), 2,
-		uintptr(unsafe.Pointer(&buf[0])),
-		uintptr(0x1000),
-		0,
-	)
-	if !NtSuccess(uint32(ret)) {
-		return "", fmt.Errorf("NTStatus(0x%X)", ret)
-	}
-	name := (*objectTypeInformation)(unsafe.Pointer(&buf[0])).TypeName.String()
-	runtime.KeepAlive(buf)
-	return name, nil
-}
-
-func queryNameInformation(handle systemHandle, ownprocess windows.Handle, ownpid bool) (string, error) {
-	// duplicate handle if it's not from our own process
-	var h windows.Handle
-	if !ownpid {
-		p, err := windows.OpenProcess(
-			windows.PROCESS_DUP_HANDLE,
-			true,
-			uint32(handle.UniqueProcessID),
-		)
-		if err != nil {
-			return "", err
-		}
-		defer windows.CloseHandle(p)
-		if err := windows.DuplicateHandle(
-			p,
-			windows.Handle(handle.HandleValue),
-			ownprocess,
-			&h,
-			0,
-			false,
-			windows.DUPLICATE_SAME_ACCESS,
-		); err != nil {
-			return "", err
-		}
-		defer windows.CloseHandle(h)
-	} else {
-		h = windows.Handle(handle.HandleValue)
-	}
-	log("query (access 0x%X)", handle.GrantedAccess)
-	buf := make([]byte, 0x1000)
-	ret, _, _ := procNtQueryObject.Call(
-		uintptr(h),
-		1,
-		uintptr(unsafe.Pointer(&buf[0])),
-		uintptr(0x1000),
-		0,
-	)
-	if !NtSuccess(uint32(ret)) {
-		return "", fmt.Errorf("NTStatus(0x%X)", ret)
-	}
-	name := (*objectNameInformation)(unsafe.Pointer(&buf[0])).Name.String()
-	runtime.KeepAlive(buf)
-	return name, nil
-}
-
-func (u unicodeString) String() string {
-	var s []uint16
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
-	hdr.Data = uintptr(unsafe.Pointer(u.Buffer))
-	hdr.Len = int(u.Length / 2)
-	hdr.Cap = int(u.MaximumLength / 2)
-	log("converting unicode string with length %d and capacity %d", u.Length, u.MaximumLength)
-	return string(utf16.Decode(s))
 }
 
 var writer io.Writer

--- a/inspector.go
+++ b/inspector.go
@@ -1,0 +1,211 @@
+package handle
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// Inspector describes a structure that queries details (name and type name) to a specific handle.
+// Common elements such as type ID to name mappings and process handles are cached and reused.
+type Inspector struct {
+	queryId        int // unique identifier for this object, used to identify object to native thread
+	typeMapping    map[uint8]string
+	processHandles map[uint16]windows.Handle
+	timeout        time.Duration
+	ntQueryThread  nativeThread
+}
+
+func NewInspector(timeout time.Duration) *Inspector {
+	queryMapMutex.Lock()
+	defer queryMapMutex.Unlock()
+	query := &Inspector{
+		queryId:        nextQueryId,
+		typeMapping:    map[uint8]string{},
+		processHandles: map[uint16]windows.Handle{},
+		timeout:        timeout,
+	}
+	nextQueryId++
+	queryMap[query.queryId] = ioChannel{
+		input:  make(chan ntObjectQuery),
+		output: make(chan interface{}),
+	}
+	return query
+}
+
+// ioChannel describes a pair of channels that is used to communicate with the native thread that calls NtQueryObject.
+// The input channel receives each parameter pair for NtQueryObject and the native thread responds with the name or
+// type name, if successful, or and error value if not successful.
+type ioChannel struct {
+	input  chan ntObjectQuery
+	output chan interface{}
+}
+
+// maps the unique ID of each Inspector object to its native thread communication channels.
+var queryMap = map[int]ioChannel{}
+var queryMapMutex sync.Mutex
+var nextQueryId int
+
+// Close the Inspector object, removing any cached data and stopping the native thread
+func (i *Inspector) Close() {
+	queryMapMutex.Lock()
+	defer queryMapMutex.Unlock()
+	close(queryMap[i.queryId].input) // Implicitly causes the native thread to exit if it is running
+	delete(queryMap, i.queryId)
+	for _, handle := range i.processHandles {
+		if handle != 0 {
+			windows.CloseHandle(handle)
+		}
+	}
+}
+
+var ownpid = uint16(os.Getpid())
+
+// LookupHandleType returns the type name for the handle. If possible, a cached type
+// is used; otherwise, the handle is duplicated and its type is looked up.
+func (i *Inspector) LookupHandleType(handle SystemHandle) (handleType string, err error) {
+	handleType, knownType := i.typeMapping[handle.ObjectTypeIndex]
+	if knownType {
+		return handleType, nil
+	}
+	var h windows.Handle
+	// duplicate handle if it's not from our own process
+	if handle.UniqueProcessID != ownpid {
+		h, err = i.duplicateHandle(handle)
+		if err != nil {
+			return "", fmt.Errorf("could not duplicate handle: %w", err)
+		}
+		defer windows.CloseHandle(h)
+	} else {
+		h = windows.Handle(handle.HandleValue)
+	}
+	handleType, err = i.ntQueryObject(h, typeInformationClass)
+	i.typeMapping[handle.ObjectTypeIndex] = handleType
+	if err != nil {
+		return "", fmt.Errorf("could not query handle type: %w", err)
+	}
+	return
+}
+
+func (i *Inspector) LookupHandleName(handle SystemHandle) (name string, err error) {
+	var h windows.Handle
+	// duplicate handle if it's not from our own process
+	if handle.UniqueProcessID != ownpid {
+		h, err = i.duplicateHandle(handle)
+		if err != nil {
+			return "", fmt.Errorf("could not duplicate handle: %w", err)
+		}
+		defer windows.CloseHandle(h)
+	} else {
+		h = windows.Handle(handle.HandleValue)
+	}
+	name, err = i.ntQueryObject(h, nameInformationClass)
+	return
+}
+
+// duplicateHandle duplicates a handle into our own process. It uses a cache for
+// process handles that are used repeatedly.
+func (i *Inspector) duplicateHandle(handle SystemHandle) (windows.Handle, error) {
+	p, hasCachedHandle := i.processHandles[handle.UniqueProcessID]
+	if !hasCachedHandle {
+		var err error
+		p, err = windows.OpenProcess(
+			windows.PROCESS_DUP_HANDLE,
+			true,
+			uint32(handle.UniqueProcessID),
+		)
+		i.processHandles[handle.UniqueProcessID] = p
+		if err != nil {
+			return 0, err
+		}
+	} else if p == 0 { // Error was cached
+		return 0, errors.New("failed to open process")
+	}
+	var h windows.Handle
+	if err := windows.DuplicateHandle(
+		p,
+		windows.Handle(handle.HandleValue),
+		windows.CurrentProcess(),
+		&h,
+		0,
+		false,
+		windows.DUPLICATE_SAME_ACCESS,
+	); err != nil {
+		return 0, err
+	}
+	return h, nil
+}
+
+// ntObjectQuery describes the parameters for a single call to NtQueryObject.
+type ntObjectQuery struct {
+	informationClass int
+	handle           windows.Handle
+}
+
+var ErrTimeout = errors.New("NtQueryObject deadlocked")
+
+// ntQueryObject wraps NtQueryObject and supports a timeout logic.
+// Because NtQueryObject can deadlock on specific handles, we do
+// not want to call it directly. We also can't call it in a separate
+// go routine because then that go routine might be permanently blocked.
+//
+// Instead, we use a native ntQueryThread that starts queryObjects and
+// communicate with it via a pair of pipes. If the response pipe times
+// out, we assume a deadlock and kill the native ntQueryThread.
+func (i *Inspector) ntQueryObject(h windows.Handle, informationClass int) (handleType string, err error) {
+	if i.ntQueryThread.IsZero() {
+		i.ntQueryThread, err = createNativeThread(queryObjectsCallback, uintptr(i.queryId))
+		if err != nil {
+			return "", err
+		}
+	}
+	queryMap[i.queryId].input <- ntObjectQuery{
+		informationClass: informationClass,
+		handle:           h,
+	}
+	select {
+	case result := <-queryMap[i.queryId].output:
+		if err, isErr := result.(error); isErr {
+			return "", err
+		} else {
+			return result.(string), nil
+		}
+	case <-time.After(i.timeout):
+		i.ntQueryThread.Terminate()
+		return "", ErrTimeout
+	}
+}
+
+var queryObjectsCallback = windows.NewCallback(queryObjects)
+
+// queryObjects runs a loop where it receives handles on an input channel
+// and sends the results on an output channel. The channel pair is identified
+// by the passed ID. This is meant to be run in a native ntQueryThread to be able to
+// catch NtQueryObject deadlocks.
+func queryObjects(id uintptr) uintptr {
+	queryMapMutex.Lock()
+	channels := queryMap[int(id)]
+	queryMapMutex.Unlock()
+	for query := range channels.input {
+		var (
+			result string
+			err    error
+		)
+		switch query.informationClass {
+		case nameInformationClass:
+			result, err = ntQueryObjectName(query.handle)
+		case typeInformationClass:
+			result, err = ntQueryObjectType(query.handle)
+		}
+		if err != nil {
+			channels.output <- err
+		} else {
+			channels.output <- result
+		}
+	}
+	return 0
+}

--- a/nativethread.go
+++ b/nativethread.go
@@ -1,0 +1,67 @@
+package handle
+
+import (
+	"math"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	kernel32 = windows.NewLazyDLL("kernel32.dll")
+
+	createThread    = kernel32.NewProc("CreateThread")
+	terminateThread = kernel32.NewProc("TerminateThread")
+)
+
+type nativeThread struct {
+	handle windows.Handle
+	done   chan struct{}
+}
+
+func createNativeThread(callback uintptr, param uintptr) (nativeThread, error) {
+	var thread nativeThread
+	h, _, err := createThread.Call(
+		0,
+		0,
+		callback,
+		param,
+		0,
+		0,
+	)
+	if h == 0 {
+		return nativeThread{}, err
+	}
+	thread.handle = windows.Handle(h)
+	// If a native thread is running, the runtime might detect a deadlock if we wait for results from the native thread.
+	// To circumvent this, we run a background routine that does nothing, but is technically not dead yet.
+	thread.done = make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-thread.done:
+				return
+			case <-time.After(time.Duration(math.MaxInt64)):
+			}
+		}
+	}()
+	return thread, nil
+}
+
+func (t nativeThread) Terminate() error {
+	close(t.done)
+	r1, _, err := terminateThread.Call(
+		uintptr(t.handle),
+		0,
+	)
+	if r1 == 0 {
+		return err
+	}
+	windows.CloseHandle(t.handle)
+	t.handle = 0
+	return nil
+}
+
+func (t nativeThread) IsZero() bool {
+	return t.handle == 0
+}

--- a/queryobject.go
+++ b/queryobject.go
@@ -1,0 +1,66 @@
+package handle
+
+import (
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type objectTypeInformation struct {
+	TypeName windows.NTUnicodeString
+	_        [22]uint64 // unused
+}
+
+type objectNameInformation struct {
+	Name windows.NTUnicodeString
+}
+
+const (
+	nameInformationClass = iota + 1
+	typeInformationClass
+)
+
+func ntQueryObjectName(handle windows.Handle) (string, error) {
+	buf, err := ntQueryObject(handle, nameInformationClass)
+	if err != nil {
+		return "", err
+	}
+	name := (*objectNameInformation)(unsafe.Pointer(&buf[0])).Name.String()
+	runtime.KeepAlive(buf)
+	return name, nil
+}
+
+func ntQueryObjectType(handle windows.Handle) (string, error) {
+	buf, err := ntQueryObject(handle, typeInformationClass)
+	if err != nil {
+		return "", err
+	}
+	name := (*objectTypeInformation)(unsafe.Pointer(&buf[0])).TypeName.String()
+	runtime.KeepAlive(buf)
+	return name, nil
+}
+
+var (
+	modntdll          = windows.NewLazyDLL("ntdll.dll")
+	procNtQueryObject = modntdll.NewProc("NtQueryObject")
+)
+
+func NtSuccess(rt uint32) bool {
+	return rt < 0x8000000
+}
+
+func ntQueryObject(handle windows.Handle, informationClass int) ([]byte, error) {
+	buf := make([]byte, 0x1000)
+	ret, _, _ := procNtQueryObject.Call(
+		uintptr(handle),
+		uintptr(informationClass),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0,
+	)
+	if !NtSuccess(uint32(ret)) {
+		return nil, windows.NTStatus(ret)
+	}
+	return buf, nil
+}

--- a/querysystemhandles.go
+++ b/querysystemhandles.go
@@ -1,0 +1,47 @@
+package handle
+
+import (
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type SystemHandle struct {
+	UniqueProcessID       uint16
+	CreatorBackTraceIndex uint16
+	ObjectTypeIndex       uint8
+	HandleAttributes      uint8
+	HandleValue           uint16
+	Object                uint3264
+	GrantedAccess         uint3264
+}
+
+type systemHandleInformation struct {
+	Count uint3264
+	// ... followed by the specified number of handles
+}
+
+func NtQuerySystemHandles(buf []byte) ([]SystemHandle, error) {
+	// reset buffer, querying system information seem to require a 0-valued buffer.
+	// Without this reset, the below sysinfo.Count might be wrong.
+	for i := 0; i < len(buf); i++ {
+		buf[i] = 0
+	}
+	// load all handle information to buffer and convert it to systemHandleInformation
+	if err := windows.NtQuerySystemInformation(
+		16,
+		unsafe.Pointer(&buf[0]),
+		uint32(len(buf)),
+		nil,
+	); err != nil {
+		return nil, err
+	}
+	sysinfo := (*systemHandleInformation)(unsafe.Pointer(&buf[0]))
+	var handles []SystemHandle
+	sh := (*reflect.SliceHeader)(unsafe.Pointer(&handles))
+	sh.Data = uintptr(unsafe.Pointer(&buf[int(unsafe.Sizeof(sysinfo.Count))]))
+	sh.Len = int(sysinfo.Count)
+	sh.Cap = int(sysinfo.Count)
+	return handles, nil
+}


### PR DESCRIPTION
The current practice of filtering specific access masks out that
can cause deadlocks in NtQueryObject also causes other handles,
e.g. most named pipes, to be ignored.
To improve on this, use a native thread instead that can be killed
in case of a deadlock. Our "main" go routine can communicate with
the go function running on the native thread via a pair of pipes.